### PR TITLE
Fixing deployment Errors by docker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,10 @@
     "process-timeout": 1800,
     "fxp-asset": {
       "enabled": false
+    },
+    "allow-plugins": {
+      "yiisoft/yii2-composer": true,
+      "phpro/grumphp": true
     }
   },
   "autoload": {


### PR DESCRIPTION
### 修复官网docker部署中的错误 
以分离模式部署时 docker-compose up -d 会因为插件配置问题报错
**问题截图：**
![1](https://user-images.githubusercontent.com/46915666/204456941-33828867-b5b7-4dd8-a728-a98e549ef477.png)
![2](https://user-images.githubusercontent.com/46915666/204456971-9b0a5487-d3bd-4a85-95e5-20884bf5447c.png)


**解决办法：**
进入本地的找到本地api文件夹中的composer.json文件，允许插件安装即可成功部署，具体改动见Files Changed
![image](https://user-images.githubusercontent.com/46915666/204457463-2e1a6606-ea29-4610-bfae-915723a2409b.png)

